### PR TITLE
Added function to improve platform compatibility

### DIFF
--- a/undetected_geckodriver/constants.py
+++ b/undetected_geckodriver/constants.py
@@ -4,6 +4,6 @@ REPLACEMENT_STRING    = b'1337river'
 
 UNDETECTED_FIREFOX_PATHS = {
     "linux": "/home/$USER/.cache/undetected_firefox/",
-    "windows": "C:\\Users\\$USER\\AppData\\Local\\undetected_firefox\\",
+    "win32": "C:\\Users\\$USER\\AppData\\Local\\undetected_firefox\\",
     "darwin": "/Users/$USER/Library/Caches/undetected_firefox/",
 }

--- a/undetected_geckodriver/driver.py
+++ b/undetected_geckodriver/driver.py
@@ -14,6 +14,7 @@ from .utils  import (
     create_undetected_firefox_directory,
     get_undetected_firefox_path,
     patch_libxul_file,
+    _get_platform_dependent_params
 )
 
 # Main class #
@@ -35,7 +36,7 @@ class Firefox(RemoteWebDriver, WebDriverMixin):
 
         self.service = service if service else Service()
         options = options if options else Options()
-        options.binary_location = os.path.join(self._undetected_path, "firefox")
+        options.binary_location = os.path.join(self._undetected_path, _get_platform_dependent_params()["firefox_exec"])
 
         finder = DriverFinder(self.service, options)
 

--- a/undetected_geckodriver/utils.py
+++ b/undetected_geckodriver/utils.py
@@ -51,3 +51,13 @@ def patch_libxul_file(undetected_path: str) -> None:
     libxul_data = libxul_data.replace(TO_REPLACE_STRING, REPLACEMENT_STRING)
     with open(libxul_path, "wb") as file:
         file.write(libxul_data)
+
+
+def _get_platform_dependent_params() -> dict:
+    match sys.platform:
+        case "win32":
+            return {"firefox_exec": "firefox.exe", "firefox_path": "C:\\Program Files\\Mozilla Firefox", "xul": "xul.dll"}
+        case "darwin":
+            return {"firefox_exec": "Firefox.app", "firefox_path": "/Applications/Firefox.app/Contents/MacOS", "xul": "libxul.dylib"}
+        case _:
+            return {"firefox_exec": "firefox", "firefox_path": "/usr/lib/firefox", "xul": "libxul.so"}

--- a/undetected_geckodriver/utils.py
+++ b/undetected_geckodriver/utils.py
@@ -13,7 +13,7 @@ def get_webdriver_instance() -> webdriver.Firefox:
 
 
 def get_firefox_installation_path() -> str:
-    firefox_path = "/usr/lib/firefox"
+    firefox_path = _get_platform_dependent_params()["firefox_path"]
     if not os.path.exists(firefox_path):
         raise FileNotFoundError("Could not find the Firefox path")
     return firefox_path
@@ -36,9 +36,10 @@ def create_undetected_firefox_directory(firefox_path: str, undetected_path: str)
 
 
 def patch_libxul_file(undetected_path: str) -> None:
-    libxul_path = os.path.join(undetected_path, "libxul.so")
+    xul = _get_platform_dependent_params()["xul"]
+    libxul_path = os.path.join(undetected_path, xul)
     if not os.path.exists(libxul_path):
-        raise FileNotFoundError("Could not find libxul.so (What the hell?!)")
+        raise FileNotFoundError(f"Could not find {xul} (What the hell?!)")
 
     if len(REPLACEMENT_STRING) != len(TO_REPLACE_STRING):
         raise ValueError(


### PR DESCRIPTION
# Platform
Operating System: Windows 11
Python Version: 3.12.7
Selenium Version: 4.25.0

# Summary
I added a function _get_platform_dependent_params to make the package compatible with other platforms. When I first tried this package, I encountered errors coming from get_firefox_installation_path, get_undetected_firefox_path, patch_libxul_file, and the Firefox class constructor. The errors stem from hard-coded strings referring to Firefox in the Linux OS. The function that I added will help to at least put all the hard-coded paths in one place and adapt values based on the user platform.

I think this also fixes #1 although I wasn't able to test it out in MacOS. The changes should be minimal if it still doesn't work in it.

Aside from this, I also made a minor change in the constants in which the Firefox path key in "windows" is changed to "win32".